### PR TITLE
Add 'options' attribute to each chart type for customizability

### DIFF
--- a/chart-bar.html
+++ b/chart-bar.html
@@ -37,6 +37,7 @@ It is sometimes used to show trend data, and the comparison of multiple data set
         "148,159,177",
         "77,83,96"
       ],
+      options: {},
       observe: {
         labels: 'updateChart',
         colors: 'updateChart',

--- a/chart-bar.html
+++ b/chart-bar.html
@@ -19,7 +19,7 @@ It is sometimes used to show trend data, and the comparison of multiple data set
 @status alpha
 @homepage http://robdodson.github.io/chart-elements
 -->
-<polymer-element name="chart-bar" attributes="width height labels values colors">
+<polymer-element name="chart-bar" attributes="width height labels values colors options">
   <template>
     <canvas id="canvas" width="{{width}}" height="{{height}}"></canvas>
   </template>
@@ -59,7 +59,7 @@ It is sometimes used to show trend data, and the comparison of multiple data set
         this.data = { labels: this.labels, datasets: this.datasets };
 
         this.ctx = this.$.canvas.getContext('2d');
-        this.chart = new Chart(this.ctx).Bar(this.data);
+        this.chart = new Chart(this.ctx).Bar(this.data, this.options);
       }
     });
   </script>

--- a/chart-doughnut.html
+++ b/chart-doughnut.html
@@ -19,7 +19,7 @@ They are also registered under two aliases in the Chart core. Other than their d
 @status alpha
 @homepage http://robdodson.github.io/chart-elements
 -->
-<polymer-element name="chart-doughnut" attributes="width height values colors">
+<polymer-element name="chart-doughnut" attributes="width height values colors options">
   <template>
     <canvas id="canvas" width="{{width}}" height="{{height}}"></canvas>
   </template>
@@ -27,6 +27,7 @@ They are also registered under two aliases in the Chart core. Other than their d
     Polymer({
       values: [30, 50, 100, 40, 120],
       colors: ["#F7464A", "#46BFBD", "#FDB45C", "#949FB1", "#4D5360"],
+      options: {},
       observe: {
         colors: 'updateChart',
         values: 'updateChart'
@@ -41,7 +42,7 @@ They are also registered under two aliases in the Chart core. Other than their d
         }, this);
 
         this.ctx = this.$.canvas.getContext('2d');
-        this.chart = new Chart(this.ctx).Doughnut(this.data);
+        this.chart = new Chart(this.ctx).Doughnut(this.data, this.options);
       }
 
     });

--- a/chart-line.html
+++ b/chart-line.html
@@ -38,6 +38,7 @@ Often, it is used to show trend data, and the comparison of two data sets.
         "148,159,177",
         "77,83,96"
       ],
+      options: {},
       observe: {
         labels: 'updateChart',
         colors: 'updateChart',

--- a/chart-line.html
+++ b/chart-line.html
@@ -20,7 +20,7 @@ Often, it is used to show trend data, and the comparison of two data sets.
 @homepage http://robdodson.github.io/chart-elements
 -->
 
-<polymer-element name="chart-line" attributes="width height labels values colors">
+<polymer-element name="chart-line" attributes="width height labels values colors options">
   <template>
     <canvas id="canvas" width="{{width}}" height="{{height}}"></canvas>
   </template>
@@ -61,7 +61,7 @@ Often, it is used to show trend data, and the comparison of two data sets.
 
         this.data = { labels: this.labels, datasets: this.datasets };
         this.ctx = this.$.canvas.getContext('2d');
-        this.chart = new Chart(this.ctx).Line(this.data);
+        this.chart = new Chart(this.ctx).Line(this.data, this.options);
       }
     });
   </script>

--- a/chart-pie.html
+++ b/chart-pie.html
@@ -19,7 +19,7 @@ They are also registered under two aliases in the Chart core. Other than their d
 @status alpha
 @homepage http://robdodson.github.io/chart-elements
 -->
-<polymer-element name="chart-pie" attributes="width height values colors">
+<polymer-element name="chart-pie" attributes="width height values colors options">
   <template>
     <style>
     :host {
@@ -32,6 +32,7 @@ They are also registered under two aliases in the Chart core. Other than their d
     Polymer({
       values: [30, 50, 100, 40, 120],
       colors: ["#F7464A", "#46BFBD", "#FDB45C", "#949FB1", "#4D5360"],
+      options: {},
       observe: {
         colors: 'updateChart',
         values: 'updateChart'
@@ -46,7 +47,7 @@ They are also registered under two aliases in the Chart core. Other than their d
         }, this);
 
         this.ctx = this.$.canvas.getContext('2d');
-        this.chart = new Chart(this.ctx).Pie(this.data);
+        this.chart = new Chart(this.ctx).Pie(this.data, this.options);
       }
     });
   </script>

--- a/chart-polar-area.html
+++ b/chart-polar-area.html
@@ -15,7 +15,7 @@ This type of chart is often useful when we want to show a comparison data simila
 @status alpha
 @homepage http://robdodson.github.io/chart-elements
 -->
-<polymer-element name="chart-polar-area" attributes="width height values colors">
+<polymer-element name="chart-polar-area" attributes="width height values colors options">
   <template>
     <canvas id="canvas" width="{{width}}" height="{{height}}"></canvas>
   </template>
@@ -23,6 +23,7 @@ This type of chart is often useful when we want to show a comparison data simila
     Polymer("chart-polar-area", {
       values: [30, 90, 18, 58, 82],
       colors: ["#46BFBD", "#FDB45C", "#949FB1", "#4D5360", "#F7464A"],
+      options: {},
       observe: {
         labels: 'updateChart',
         colors: 'updateChart',
@@ -38,7 +39,7 @@ This type of chart is often useful when we want to show a comparison data simila
         }, this);
 
         this.ctx = this.$.canvas.getContext('2d');
-        this.chart = new Chart(this.ctx).PolarArea(this.data);
+        this.chart = new Chart(this.ctx).PolarArea(this.data, this.options);
       }
     });
   </script>

--- a/chart-radar.html
+++ b/chart-radar.html
@@ -18,7 +18,7 @@ They are often useful for comparing the points of two or more different data set
 @status alpha
 @homepage http://robdodson.github.io/chart-elements
 -->
-<polymer-element name="chart-radar" attributes="width height labels values colors">
+<polymer-element name="chart-radar" attributes="width height labels values colors options">
   <template>
     <canvas id="canvas" width="{{width}}" height="{{height}}"></canvas>
   </template>
@@ -36,6 +36,7 @@ They are often useful for comparing the points of two or more different data set
         "148,159,177",
         "77,83,96"
       ],
+      options: {},
       observe: {
         colors: 'updateChart',
         values: 'updateChart',
@@ -58,7 +59,7 @@ They are often useful for comparing the points of two or more different data set
 
         this.data = { labels: this.labels, datasets: this.datasets };
         this.ctx = this.$.canvas.getContext('2d');
-        this.chart = new Chart(this.ctx).Radar(this.data);
+        this.chart = new Chart(this.ctx).Radar(this.data, this.options);
       }
     });
   </script>


### PR DESCRIPTION
I've added an 'options' attribute which lets the user change basic stylings such as turning off point dots, bezier smoothing and the (wonky) initial bounce easing animation.  If you accept the PR I'd recommend updating the appropriate documentation so folks know to reference the Chart.js options documented at http://www.chartjs.org/docs/#line-chart-chart-options.
