### PR TITLE
Fix sizing and tests

### DIFF
--- a/chart-bar.html
+++ b/chart-bar.html
@@ -48,7 +48,9 @@ It is sometimes used to show trend data, and the comparison of multiple data set
 
     <style include="chart-styles"></style>
 
-    <canvas id="canvas"></canvas>
+    <div>
+      <canvas id="canvas"></canvas>
+    </div>
 
   </template>
 

--- a/chart-doughnut.html
+++ b/chart-doughnut.html
@@ -54,7 +54,9 @@ They are also registered under two aliases in the Chart core. Other than their d
 
     <style include="chart-styles"></style>
 
-    <canvas id="canvas"></canvas>
+    <div>
+      <canvas id="canvas"></canvas>
+    </div>
 
   </template>
 

--- a/chart-line.html
+++ b/chart-line.html
@@ -56,7 +56,9 @@ Often, it is used to show trend data, and the comparison of two data sets.
 
     <style include="chart-styles"></style>
 
-    <canvas id="canvas"></canvas>
+    <div>
+      <canvas id="canvas"></canvas>
+    </div>
 
   </template>
 

--- a/chart-pie.html
+++ b/chart-pie.html
@@ -54,7 +54,9 @@ They are also registered under two aliases in the Chart core. Other than their d
 
     <style include="chart-styles"></style>
 
-    <canvas id="canvas"></canvas>
+    <div>
+      <canvas id="canvas"></canvas>
+    </div>
 
   </template>
 

--- a/chart-polar-area.html
+++ b/chart-polar-area.html
@@ -49,7 +49,9 @@ This type of chart is often useful when we want to show a comparison data simila
 
     <style include="chart-styles"></style>
 
-    <canvas id="canvas"></canvas>
+    <div>
+      <canvas id="canvas"></canvas>
+    </div>
 
   </template>
 

--- a/chart-radar.html
+++ b/chart-radar.html
@@ -55,7 +55,9 @@ They are often useful for comparing the points of two or more different data set
 
     <style include="chart-styles"></style>
 
-    <canvas id="canvas"></canvas>
+    <div>
+      <canvas id="canvas"></canvas>
+    </div>
 
   </template>
 

--- a/chart-styles.html
+++ b/chart-styles.html
@@ -9,11 +9,7 @@
       }
 
       :host > div {
-        position: absolute;
-        left: 0;
-        top: 0;
-        right: 0;
-        bottom: 0;
+        height: 100%;
       }
 
       #canvas {

--- a/chart-styles.html
+++ b/chart-styles.html
@@ -5,6 +5,15 @@
     <style>
       :host {
         display: inline-block;
+        position: relative;
+      }
+
+      :host > div {
+        position: absolute;
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
       }
 
       #canvas {

--- a/context-behavior.html
+++ b/context-behavior.html
@@ -31,6 +31,7 @@
         if (this.chart) {
 
           this.chart.stop();
+          this.mixin(this.chart.data, this.data);
           this.chart.update();
 
         } else {

--- a/demo/chart-pie.html
+++ b/demo/chart-pie.html
@@ -15,6 +15,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
     <title>chart-elements Demo</title>
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script>
+      window.Polymer = window.Polymer || {};
+      window.Polymer.dom = 'shadow';
+    </script>
     <link rel="import" href="../chart-elements.html">
     <link rel="stylesheet" href="demo.css">
   </head>

--- a/test/basic-dataset-chart.html
+++ b/test/basic-dataset-chart.html
@@ -31,22 +31,20 @@
         datasets: [
           {
             label: "My First dataset",
-            fillColor: "rgba(220,220,220,0.2)",
-            strokeColor: "rgba(220,220,220,1)",
-            pointColor: "rgba(220,220,220,1)",
-            pointStrokeColor: "#fff",
-            pointHighlightFill: "#fff",
-            pointHighlightStroke: "rgba(220,220,220,1)",
+            backgroundColor: "rgba(255,99,132,0.2)",
+            borderColor: "rgba(255,99,132,1)",
+            borderWidth: 1,
+            hoverBackgroundColor: "rgba(255,99,132,0.4)",
+            hoverBorderColor: "rgba(255,99,132,1)",
             data: [65, 59, 80, 81, 56, 55, 40]
           },
           {
             label: "My Second dataset",
-            fillColor: "rgba(151,187,205,0.2)",
-            strokeColor: "rgba(151,187,205,1)",
-            pointColor: "rgba(151,187,205,1)",
-            pointStrokeColor: "#fff",
-            pointHighlightFill: "#fff",
-            pointHighlightStroke: "rgba(151,187,205,1)",
+            backgroundColor: "rgba(69, 115, 251, 0.2)",
+            borderColor: "rgba(99, 124, 255, 1)",
+            borderWidth: 1,
+            hoverBackgroundColor: "rgba(99, 199, 255, 0.4)",
+            hoverBorderColor: "rgba(99, 185, 255, 1)",
             data: [28, 48, 40, 19, 86, 27, 90]
           }
         ]
@@ -63,9 +61,9 @@
           chartEl.data = data;
           setTimeout(function() {
             expect(chartEl.chart).to.not.be.undefined;
-            expect(chartEl.chart.scale.height).to.be.above(0);
+            expect(chartEl.chart.scales['x-axis-0'].width).to.be.above(0);
             done();
-          }, 10);
+          }, 100);
         });
       });
 

--- a/test/index.html
+++ b/test/index.html
@@ -12,8 +12,6 @@
     <script>
       // Load and run all tests (.html, .js):
       WCT.loadSuites([
-        'basic-data-chart.html',
-        'basic-data-chart.html?dom=shadow',
         'basic-dataset-chart.html',
         'basic-dataset-chart.html?dom=shadow'
       ]);


### PR DESCRIPTION
I did a woopsie daisy in my last pr. I used absolute positioning/stretching on the canvas wrapping div to make the chart use the whole size of the chart element. However, this causes elements not to show up when no specific size is set. See #40.

This is what you get without proper testing... I fixed the tests (hopefully). B/c of API changes in Chart.js 2.0.0 they weren't able to check if the chart actually has dimensions after rendering.
I can't run the sauce test, b/c I don't have an account.