### PR TITLE
Freeze Chart.js depency.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.1.0",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#~1.0.2",
-    "Chart.js": "^2.1.3"
+    "Chart.js": "2.1.6"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",


### PR DESCRIPTION
They droped bower support in 2.2.x.
Tmp fix for #53.