### PR TITLE
Unfreeze Chart.js dependency.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.1.0",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#~1.0.2",
-    "Chart.js": "2.1.6"
+    "Chart.js": "^2.0.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",


### PR DESCRIPTION
Dist files now come included again. See https://github.com/chartjs/Chart.js/issues/3033 for background.

Fixes #53