### PR TITLE
Fixes issue #64

### DIFF
--- a/components/chart-elements/chart-doughnut.html
+++ b/components/chart-elements/chart-doughnut.html
@@ -16,7 +16,7 @@ They are also registered under two aliases in the Chart core. Other than their d
 
 ##### Example
 
-    <chart-doughnut values="{{data}}"></chart-doughnut>
+    <chart-doughnut data="{{data}}"></chart-doughnut>
 
     ...
 


### PR DESCRIPTION
The documentation stated that the attribute's name to assign the data to the chart was `values` and instead the right name is: `data`.