### PR TITLE
Fix getComputedStyle null value from Chart.js in IE 11

### DIFF
--- a/chart-property-mixin.js
+++ b/chart-property-mixin.js
@@ -36,7 +36,9 @@ export const ChartPropertyMixin = function(superClass) {
 
     render() {
       return html`
-        <canvas id="canvas"></canvas>
+        <div>
+          <canvas id="canvas"></canvas>
+        </div>
       `;
     }
 


### PR DESCRIPTION
Hello!

I found a bug when a chart component is used in IE11. 

Since the components has been migrated to lit I get this error on chart-pie draw:

`Unable to get property 'getPropertyValue' of undefined or null reference`

The error is raised when the library Chart.js try to get a computed styles, this is due to the `_getParentNode` helper function cannot get the right parent of `canvas` because the parent is not an HTML element but a Javascript object.

The problem is solved wrapping the `canvas` element with a `div`, in this way Chart.js can get a parent HTML element and calculate the styles properly.

Actually in the polymer version there was a `div` wrapping the canvas, I guess for this reason, but in the migration to lit was lost.